### PR TITLE
Fix bad URL on Google Play store for Paraglidable android app

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -90,7 +90,7 @@
     <div class="dropdown-content">
         <ul>
             <li id="mobileVersionLink" onclick="window.location.href='mobile.html'">Mobile version</li>
-            <li id="androidAppLink" onclick="window.open('https://play.google.com/store/app/details?id=com.paraglidable.paraglidable','_blank')">Android app</li>
+            <li id="androidAppLink" onclick="window.open('https://play.google.com/store/apps/details?id=com.paraglidable.paraglidable','_blank')">Android app</li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
The URL of the Paraglidable app on Google Play store leaded to a 404 error
I just fixed this URL
a simple s was missing